### PR TITLE
Update k6 Prometheus remote write port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -128,6 +128,7 @@ services:
       - ./otel-collector-config.yml:/etc/otel-collector-config.yml
     ports:
       - "9464:9464"
+      - "9465:9465"
 
   prometheus:
     image: prom/prometheus:v2.52.0
@@ -145,5 +146,5 @@ services:
     image: grafana/k6:0.50.0
     entrypoint: [ "sh", "-c", "sleep infinity" ]
     environment:
-      K6_PROMETHEUS_RW_SERVER_URL: http://otel-collector:9464/api/v1/write
+      K6_PROMETHEUS_RW_SERVER_URL: http://otel-collector:9465/api/v1/write
     depends_on: [ otel-collector ]

--- a/otel-collector-config.yml
+++ b/otel-collector-config.yml
@@ -4,7 +4,7 @@ receivers:
       grpc:
       http:
   prometheusremotewrite:
-    endpoint: 0.0.0.0:9464
+    endpoint: 0.0.0.0:9465
 
 processors:
   batch:

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,7 +1,7 @@
 global:
   scrape_interval: 15s
 scrape_configs:
-  # scrape OpenTelemetry Collector metrics (includes k6 remote‑write data that the collector reshapes)
+  # scrape OpenTelemetry Collector metrics (includes k6 remote‑write data that the collector reshapes, now sent to port 9465)
   - job_name: 'otel-collector'
     static_configs:
       - targets: ['otel-collector:9464']


### PR DESCRIPTION
## Summary
- expose port 9465 for the k6 Prometheus remote-write endpoint
- change remote write endpoint in otel collector
- update k6 environment variable
- clarify new port in Prometheus config comment

## Testing
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886122ebadc832389abf1071f634032