### PR TITLE
Configure Jaeger exporter

### DIFF
--- a/otel-collector-config.yml
+++ b/otel-collector-config.yml
@@ -10,6 +10,10 @@ processors:
   batch:
 
 exporters:
+  otlp/jaeger:
+    endpoint: jaeger:4317
+    tls:
+      insecure: true
   prometheus:
     endpoint: 0.0.0.0:9464
 


### PR DESCRIPTION
## Summary
- add otlp/jaeger exporter definition in `otel-collector-config.yml`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6886122a08588323a38b8dbac3364f14